### PR TITLE
Fix #7: Added NIO SPI FileTypeDetector service

### DIFF
--- a/src/main/java/org/overviewproject/mime_types/FileTypeDetector.java
+++ b/src/main/java/org/overviewproject/mime_types/FileTypeDetector.java
@@ -1,0 +1,21 @@
+package org.overviewproject.mime_types;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Detects the mime type of files (ideally based on marker in file content)
+ */
+public class FileTypeDetector extends java.nio.file.spi.FileTypeDetector {
+
+    private final MimeTypeDetector mimeTypeDetector = new MimeTypeDetector();
+    
+    @Override
+    public String probeContentType(Path path) throws IOException {
+        try {
+            return mimeTypeDetector.detectMimeType(path.toFile());
+        } catch (GetBytesException ex) {
+            throw new IOException(ex);
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/java.nio.file.spi.FileTypeDetector
+++ b/src/main/resources/META-INF/services/java.nio.file.spi.FileTypeDetector
@@ -1,0 +1,1 @@
+org.overviewproject.mime_types.FileTypeDetector


### PR DESCRIPTION
Now this can be injected as an SPI and used in the standard Files API.

```java
String mimeType =  Files.probeContentType(tempFile);
```
