### PR TITLE
Fix bug where empty filname leads to an exception instead of skipping filename parsing strategy for determining mimetype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,10 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M6</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.2.0</version>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -113,26 +113,8 @@
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>5.9.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.9.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <version>1.9.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <version>1.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -151,10 +133,6 @@
            <source>1.8</source>
            <target>1.8</target>
         </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M6</version>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
@@ -177,6 +155,11 @@
           <releaseProfiles>release</releaseProfiles>
           <goals>deploy</goals>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M7</version>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/org/overviewproject/mime_types/MimeTypeDetector.java
+++ b/src/main/java/org/overviewproject/mime_types/MimeTypeDetector.java
@@ -549,6 +549,10 @@ public class MimeTypeDetector {
     }
 
     private Set<WeightedMimeType> filenameToWmts(String filename) {
+        if("".equals(filename) || null == filename){
+            return new HashSet<>();
+        }
+
         Set<WeightedMimeType> ret;
         WeightedMimeType wmt;
 

--- a/src/test/java/org/overviewproject/mime_types/MimeTypeDetectorTest.java
+++ b/src/test/java/org/overviewproject/mime_types/MimeTypeDetectorTest.java
@@ -1,6 +1,7 @@
 package org.overviewproject.mime_types;
 
 import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -13,8 +14,19 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class MimeTypeDetectorTest extends TestCase {
     private final MimeTypeDetector detector = new MimeTypeDetector();
+
+    @Test
+    public void testEmptyStringNullSafe() throws GetBytesException {
+        InputStream is = getTestResource("empty");
+
+        String mimeType = detector.detectMimeType("", is);
+
+        assertEquals("application/octet-stream", mimeType);
+    }
 
     public void testGlobLiteral() {
         assertEquals("text/x-makefile", detectMimeType("makefile"));
@@ -72,7 +84,8 @@ public class MimeTypeDetectorTest extends TestCase {
     }
 
     public void testRespectsMagicFileOrdering() {
-        // MIME candidates are found in this order for this file: "application/ogg", "audio/ogg", "video/ogg" (note, the superclass comes first)
+        // MIME candidates are found in this order for this file: "application/ogg", "audio/ogg", "video/ogg" (note, the superclass comes
+        // first)
         // however, if a HashSet is used internally, the iterable order will be something like: "audio/ogg", "application/ogg", "video/ogg"
         // and "audio/ogg" is returned for video as well as audio (not good)
         assertEquals("application/ogg", detectMimeType("ogv-video-header"));
@@ -89,11 +102,15 @@ public class MimeTypeDetectorTest extends TestCase {
     }
 
     private String detectMimeType(String resourceName) {
-        try (InputStream is = getClass().getResourceAsStream("/test/" + resourceName)) {
+        try (InputStream is = getTestResource(resourceName)) {
             return detector.detectMimeType(resourceName, is);
         } catch (GetBytesException | IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private InputStream getTestResource(String resourceName) {
+        return getClass().getResourceAsStream("/test/" + resourceName);
     }
 
     public void testEmptyFile() throws IOException, GetBytesException {

--- a/src/test/java/org/overviewproject/mime_types/MimeTypeDetectorTest.java
+++ b/src/test/java/org/overviewproject/mime_types/MimeTypeDetectorTest.java
@@ -13,7 +13,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
-
 public class MimeTypeDetectorTest extends TestCase {
     private final MimeTypeDetector detector = new MimeTypeDetector();
 
@@ -79,8 +78,7 @@ public class MimeTypeDetectorTest extends TestCase {
     }
 
     public void testRespectsMagicFileOrdering() {
-        // MIME candidates are found in this order for this file: "application/ogg", "audio/ogg", "video/ogg" (note, the superclass comes
-        // first)
+        // MIME candidates are found in this order for this file: "application/ogg", "audio/ogg", "video/ogg" (note, the superclass comes first)
         // however, if a HashSet is used internally, the iterable order will be something like: "audio/ogg", "application/ogg", "video/ogg"
         // and "audio/ogg" is returned for video as well as audio (not good)
         assertEquals("application/ogg", detectMimeType("ogv-video-header"));

--- a/src/test/java/org/overviewproject/mime_types/MimeTypeDetectorTest.java
+++ b/src/test/java/org/overviewproject/mime_types/MimeTypeDetectorTest.java
@@ -1,7 +1,6 @@
 package org.overviewproject.mime_types;
 
 import junit.framework.TestCase;
-import org.junit.Test;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -14,18 +13,14 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MimeTypeDetectorTest extends TestCase {
     private final MimeTypeDetector detector = new MimeTypeDetector();
 
-    @Test
     public void testEmptyStringNullSafe() throws GetBytesException {
         InputStream is = getTestResource("empty");
 
-        String mimeType = detector.detectMimeType("", is);
-
-        assertEquals("application/octet-stream", mimeType);
+        assertEquals("application/octet-stream", detector.detectMimeType("", is));
     }
 
     public void testGlobLiteral() {

--- a/src/test/java/org/overviewproject/mime_types/MimeTypeDetectorTest.java
+++ b/src/test/java/org/overviewproject/mime_types/MimeTypeDetectorTest.java
@@ -1,6 +1,7 @@
 package org.overviewproject.mime_types;
 
-import junit.framework.TestCase;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -13,21 +14,27 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
-public class MimeTypeDetectorTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MimeTypeDetectorTest {
     private final MimeTypeDetector detector = new MimeTypeDetector();
 
-    public void testEmptyStringNullSafe() throws GetBytesException {
+    @Test
+    void emptyStringNullSafe() throws GetBytesException {
         InputStream is = getTestResource("empty");
 
         assertEquals("application/octet-stream", detector.detectMimeType("", is));
     }
 
-    public void testGlobLiteral() {
+    @Test
+    void globLiteral() {
         assertEquals("text/x-makefile", detectMimeType("makefile"));
         assertEquals("text/x-makefile", detectMimeType("Makefile"));
     }
 
-    public void testGlobExtension() {
+    @Test
+    void globExtension() {
         // These files don't exist; if the test throws NullPointerException
         // that's because we need to read the file. We shouldn't need to read
         // these files because the extension should be enough.
@@ -40,7 +47,8 @@ public class MimeTypeDetectorTest extends TestCase {
         assertEquals("application/vnd.ms-outlook", detectMimeType("t.pst"));
     }
 
-    public void testGlobFilename() {
+    @Test
+    void globFilename() {
         assertEquals("text/x-readme", detectMimeType("README"));
         assertEquals("text/x-readme", detectMimeType("READMEFILE"));
         assertEquals("text/x-readme", detectMimeType("READMEanim3"));
@@ -48,48 +56,58 @@ public class MimeTypeDetectorTest extends TestCase {
         assertEquals("text/x-readme", detectMimeType("README.file"));
     }
 
-    public void testOctetStream() {
+    @Test
+    void octetStream() {
         assertEquals("application/octet-stream", detectMimeType("empty"));
         assertEquals("application/octet-stream", detectMimeType("octet-stream"));
     }
 
-    public void testMultipleExtensions() {
+    @Test
+    void multipleExtensions() {
         assertEquals("application/x-java-archive", detectMimeType("e.1.3.jar"));
     }
 
-    public void testMagic() {
+    @Test
+    void magic() {
         assertEquals("application/xml", detectMimeType("e[xml]"));
     }
 
-    public void testMagicIndent() {
+    @Test
+    void magicIndent() {
         // "a\n" will match image/x-pcx if rules are treated as OR instead of AND.
         assertEquals("text/plain", detectMimeType("a"));
     }
 
-    public void testText() {
+    @Test
+    void text() {
         assertEquals("text/plain", detectMimeType("plaintext"));
         assertEquals("text/plain", detectMimeType("textfiles/utf-8"));
         assertEquals("text/plain", detectMimeType("textfiles/windows-1255"));
     }
 
-    public void testMatchletSearchIsThorough() {
+    @Test
+    void matchletSearchIsThorough() {
         // returns application/octet-stream if the entire matchlet range is not searched
         assertEquals("application/x-matroska", detectMimeType("mkv-video-header"));
     }
 
-    public void testRespectsMagicFileOrdering() {
-        // MIME candidates are found in this order for this file: "application/ogg", "audio/ogg", "video/ogg" (note, the superclass comes first)
+    @Test
+    void respectsMagicFileOrdering() {
+        // MIME candidates are found in this order for this file: "application/ogg", "audio/ogg", "video/ogg" (note, the superclass comes
+        // first)
         // however, if a HashSet is used internally, the iterable order will be something like: "audio/ogg", "application/ogg", "video/ogg"
         // and "audio/ogg" is returned for video as well as audio (not good)
         assertEquals("application/ogg", detectMimeType("ogv-video-header"));
     }
 
-    public void testMPEG4v1() {
+    @Test
+    void mPEG4v1() {
         // ISO Media, MP4 v1 [ISO 14496-1:ch13] - new in shared-mime-info-1.13.1
         assertEquals("video/mp4", detectMimeType("mp4v1-video-header"));
     }
 
-    public void testMPEG4v2() {
+    @Test
+    void mPEG4v2() {
         // ISO Media, MP4 v2 [ISO 14496-14] - included in shared-mime-info
         assertEquals("video/mp4", detectMimeType("mp4v2-video-header"));
     }
@@ -106,13 +124,15 @@ public class MimeTypeDetectorTest extends TestCase {
         return getClass().getResourceAsStream("/test/" + resourceName);
     }
 
-    public void testEmptyFile() throws IOException, GetBytesException {
+    @Test
+    void emptyFile() throws IOException, GetBytesException {
         File f = File.createTempFile("mime-type-test", ".weird");
         f.deleteOnExit();
         assertEquals("application/octet-stream", detector.detectMimeType(f));
     }
 
-    public void testFile() throws IOException, GetBytesException {
+    @Test
+    void file() throws IOException, GetBytesException {
         File f = File.createTempFile("mime-type-test", ".weird");
         f.deleteOnExit();
 
@@ -122,7 +142,8 @@ public class MimeTypeDetectorTest extends TestCase {
         assertEquals("text/plain", detector.detectMimeType(f));
     }
 
-    public void testPath() throws IOException, GetBytesException {
+    @Test
+    void path() throws IOException, GetBytesException {
         File f = File.createTempFile("mime-type-test", ".weird");
         f.deleteOnExit();
 
@@ -132,13 +153,15 @@ public class MimeTypeDetectorTest extends TestCase {
         assertEquals("text/plain", detector.detectMimeType(f.toPath()));
     }
 
-    public void testCallback() throws GetBytesException {
+    @Test
+    void callback() throws GetBytesException {
         Callable<byte[]> getBytes = () -> "foo bar baz".getBytes(StandardCharsets.UTF_8);
 
         assertEquals("text/plain", detector.detectMimeType("mime-type-test.weird", getBytes));
     }
 
-    public void testAsync() throws InterruptedException, ExecutionException {
+    @Test
+    void async() throws InterruptedException, ExecutionException {
         byte[] bytes = "foo bar baz".getBytes(StandardCharsets.UTF_8);
 
         Supplier<CompletionStage<byte[]>> getBytes = () -> CompletableFuture.completedFuture(bytes);
@@ -146,22 +169,21 @@ public class MimeTypeDetectorTest extends TestCase {
         assertEquals("text/plain", detector.detectMimeTypeAsync("mime-type-test.weird", getBytes).toCompletableFuture().get());
     }
 
-    public void testAsyncGetBytesException() throws InterruptedException {
+    @Test
+    void asyncGetBytesException() throws InterruptedException {
         Supplier<CompletionStage<byte[]>> getBytes = () -> {
             CompletableFuture<byte[]> future = new CompletableFuture<>();
             future.completeExceptionally(new GetBytesException(new IOException("oops")));
             return future;
         };
 
-        try {
-            detector.detectMimeTypeAsync("mime-type-test.weird", getBytes).toCompletableFuture().get();
-            fail("That should have thrown an exception");
-        } catch (ExecutionException ex) {
-            assertEquals(GetBytesException.class, ex.getCause().getClass());
-        }
+        Exception e = assertThrows(ExecutionException.class,
+                () -> detector.detectMimeTypeAsync("mime-type-test.weird", getBytes).toCompletableFuture().get());
+        assertEquals(GetBytesException.class, e.getCause().getClass());
     }
 
-    public void testPathAsync() throws ExecutionException, IOException, InterruptedException {
+    @Test
+    void pathAsync() throws ExecutionException, IOException, InterruptedException {
         File f = File.createTempFile("mime-type-test", ".weird");
         f.deleteOnExit();
 


### PR DESCRIPTION
I ran into this bug updating from version 1.0.2 to 1.0.3 where the comments at 
```java
    /**
     * Determines the MIME type of file with a given input stream.
     *
     * <p>
     * The InputStream must exist. It must point to the beginning of the file
     * contents. And {@link java.io.InputStream#markSupported()} must return
     * {@code true}. When in doubt, pass a {@link java.io.BufferedInputStream}.
     * </p>
     *
     * @param filename Name of file. To skip filename globbing, pass {@code ""}
     * @param is InputStream that supports mark and reset.
     * @return a MIME type such as {@code "text/plain"}
     * @throws GetBytesException if marking, reading or resetting the InputStream fails.
     * @see #detectMimeType(String, Callable)
     */
    public String detectMimeType(String filename, final InputStream is) throws GetBytesException {
```

do not seem to be correct. I've added a testcase for the behaviour that I would expect. Let me know if this looks good to you.
Also, I noticed the testcase still using the somewhat older `extends TestCase` style of unit testing. I'd be happy to do some refactoring to modernize the test a bit if you would like that.